### PR TITLE
Add default_detector field to WireMetadata class

### DIFF
--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -97,6 +97,7 @@ class WireControlInformation(ControlInformation):
 
 class WireMetadata(Metadata):
     detectors: List[str]
+    default_detector: str
     bpms_before_wire: Optional[List[str]] = None
     bpms_after_wire: Optional[List[str]] = None
     type: str

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -57,6 +57,7 @@ class WireTest(TestCase):
                 "type": "PROF",
                 "wire_type": "C",
                 "detectors": ["DET1"],
+                "default_detector": "DET1",
             },
         }
 


### PR DESCRIPTION
This pull request introduces a minor change to the `WireMetadata` class by adding a new field for the default detector. This enhances the metadata structure to explicitly specify which detector should be considered the default for a wire.  See Issue #10 