### PR TITLE
Enhance MagnetControlInformation to lazily load control options 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/slac_devices/magnet.py
+++ b/slac_devices/magnet.py
@@ -5,6 +5,7 @@ from pydantic import (
     PositiveFloat,
     NonNegativeFloat,
     SerializeAsAny,
+    PrivateAttr,
 )
 from typing import (
     Dict,
@@ -38,19 +39,25 @@ class MagnetPVSet(PVSet):
 class MagnetControlInformation(ControlInformation):
     PVs: SerializeAsAny[MagnetPVSet]
     _ctrl_options: SerializeAsAny[Optional[Dict[str, int]]] = dict()
+    _ctrl_options_loaded: bool = PrivateAttr(default=False)
 
     def __init__(self, *args, **kwargs):
         super(MagnetControlInformation, self).__init__(*args, **kwargs)
-        # Get possible options for magnet ctrl PV, empty dict by default.
+
+    def _load_ctrl_options(self):
+        if self._ctrl_options_loaded:
+            return
+        self._ctrl_options_loaded = True
+
         options = self.PVs.ctrl.get_ctrlvars(timeout=1)
-        if options:
-            [
-                self._ctrl_options.update({option: i})
-                for i, option in enumerate(options["enum_strs"])
-            ]
+        if options and "enum_strs" in options:
+            self._ctrl_options.update(
+                {option: i for i, option in enumerate(options["enum_strs"])}
+            )
 
     @property
     def ctrl_options(self):
+        self._load_ctrl_options()
         return self._ctrl_options
 
 

--- a/slac_devices/magnet.py
+++ b/slac_devices/magnet.py
@@ -47,13 +47,21 @@ class MagnetControlInformation(ControlInformation):
     def _load_ctrl_options(self):
         if self._ctrl_options_loaded:
             return
-        self._ctrl_options_loaded = True
 
         options = self.PVs.ctrl.get_ctrlvars(timeout=1)
-        if options and "enum_strs" in options:
-            self._ctrl_options.update(
-                {option: i for i, option in enumerate(options["enum_strs"])}
+        if options is not None:
+            if "enum_strs" in options:
+                self._ctrl_options.update(
+                    {option: i for i, option in enumerate(options["enum_strs"])}
+                )
+            self._ctrl_options_loaded = True
+        else:
+            pvname = self.PVs.ctrl.pvname
+            msg = (
+                "Timed out waiting for control options from PV '%s'. The PV may be disconnected."
+                % pvname
             )
+            raise TimeoutError(msg)
 
     @property
     def ctrl_options(self):

--- a/tests/test_magnet.py
+++ b/tests/test_magnet.py
@@ -122,6 +122,11 @@ class MagnetTest(TestCase):
         """Test we get expected default"""
         self.assertEqual(self.magnet.name, "SOL1B")
 
+    def test_ctrl_options_are_lazy_loaded(self) -> None:
+        self.mock_ctrl_options.assert_not_called()
+        _ = self.magnet.ctrl_options
+        self.mock_ctrl_options.assert_called_once_with(timeout=1)
+
     def test_tol(self) -> None:
         """Test tol float validation"""
         self.assertIsNone(self.magnet.b_tolerance)

--- a/tests/test_magnet.py
+++ b/tests/test_magnet.py
@@ -123,6 +123,9 @@ class MagnetTest(TestCase):
         self.assertEqual(self.magnet.name, "SOL1B")
 
     def test_ctrl_options_are_lazy_loaded(self) -> None:
+        # mock_ctrl_options patches epics.PV.get_ctrlvars; accessing
+        # ctrl_options for the first time should trigger exactly one call
+        # to get_ctrlvars(timeout=1).
         self.mock_ctrl_options.assert_not_called()
         _ = self.magnet.ctrl_options
         self.mock_ctrl_options.assert_called_once_with(timeout=1)


### PR DESCRIPTION
This pull request updates the `MagnetControlInformation` class in `slac_devices/magnet.py` to improve how control options are loaded and cached. The main change is to make the loading of control options lazy, ensuring they are only fetched when needed and only once, improving efficiency and reducing unnecessary calls. Corresponding tests are added to verify this behavior.  Addresses #14.

**Improvements to control options loading:**

* Control options in `MagnetControlInformation` are now loaded lazily using a new `_load_ctrl_options` method and a `_ctrl_options_loaded` flag, ensuring options are fetched only when first accessed. (`slac_devices/magnet.py`)
* The `_ctrl_options` dictionary is now only updated if the options are present and contain `enum_strs`, making the code more robust. (`slac_devices/magnet.py`)
* Introduced the use of `PrivateAttr` from Pydantic for the `_ctrl_options_loaded` attribute to properly manage its internal state. (`slac_devices/magnet.py`)

**Testing improvements:**

* Added a test to ensure control options are loaded lazily and only when accessed, verifying the improved behavior. (`tests/test_magnet.py`)