### PR TITLE
Add TMITLossBPMs class and update WireMetadata for tmitloss

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,16 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-toml
-      - id: check-added-large-files
-      - id: check-merge-conflict
       - id: check-ast
       - id: check-case-conflict
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix]

--- a/slac_devices/area.py
+++ b/slac_devices/area.py
@@ -63,13 +63,13 @@ def _prune_invalid_devices(
         payload_copy = dict(payload)
         payload_copy["name"] = name
         try:
-            device_class(**payload_copy)
+            device = device_class(**payload_copy)
         except (ValidationError, TypeError, Exception) as field_error:
             print(
                 f"Skipping invalid {device_type} {name} in {area_name}: {field_error}"
             )
             continue
-        valid_devices[name] = payload_copy
+        valid_devices[name] = device
 
     if not valid_devices:
         return None
@@ -212,7 +212,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_magnets:
             return None
-        return MagnetCollection(magnets=valid_magnets)
+        return MagnetCollection.model_construct(devices=valid_magnets)
 
     @field_validator(
         "screen_collection",
@@ -227,7 +227,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_screens:
             return None
-        return ScreenCollection(screens=valid_screens)
+        return ScreenCollection.model_construct(devices=valid_screens)
 
     @field_validator(
         "wire_collection",
@@ -242,7 +242,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_wires:
             return None
-        return WireCollection(wires=valid_wires)
+        return WireCollection.model_construct(wires=valid_wires)
 
     @field_validator(
         "bpm_collection",
@@ -257,7 +257,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_bpms:
             return None
-        return BPMCollection(bpms=valid_bpms)
+        return BPMCollection.model_construct(bpms=valid_bpms)
 
     @field_validator(
         "lblm_collection",
@@ -272,7 +272,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_lblms:
             return None
-        return LBLMCollection(lblms=valid_lblms)
+        return LBLMCollection.model_construct(lblms=valid_lblms)
 
     @field_validator(
         "pmt_collection",
@@ -287,7 +287,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_pmts:
             return None
-        return PMTCollection(pmts=valid_pmts)
+        return PMTCollection.model_construct(pmts=valid_pmts)
 
     @field_validator(
         "tcav_collection",
@@ -302,7 +302,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_tcavs:
             return None
-        return TCAVCollection(tcavs=valid_tcavs)
+        return TCAVCollection.model_construct(tcavs=valid_tcavs)
 
     @property
     def magnets(

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -88,8 +88,9 @@ class BPMCollection(BaseModel):
     @field_validator("bpms", mode="before")
     def validate_bpms(cls, v) -> Dict[str, BPM]:
         for name, bpm in v.items():
+            if isinstance(bpm, BPM):
+                continue
             bpm = dict(bpm)
-            # Set name field for BPM
             bpm.update({"name": name})
             v.update({name: bpm})
         return v

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -76,7 +76,7 @@ class BPM(Device):
 
     def tmit_buffer(self, buffer):
         """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get_data_buffer(self.controls_information.PVs.tmit.pvname)
+        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:TMIT")
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -252,6 +252,8 @@ class DeviceCollection(slac_devices.BaseModel):
         and then use that dictionary to create each Device.
         """
         for name, device in v.items():
+            if isinstance(device, Device):
+                continue
             device = dict(device)
             device.update({"name": name})
             v.update({name: device})

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -49,10 +49,12 @@ class PVSet(slac_devices.BaseModel):
         frozen=True,
     )
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> LazyPV:
+    @field_validator("*", mode="wrap")
+    def validate_pv_fields(cls, v, handler) -> LazyPV:
         if v is None:
             return None
+        if isinstance(v, LazyPV):
+            return v
         return LazyPV(v)
 
     @field_serializer("*", when_used="unless-none")

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -4,6 +4,44 @@ from typing import List, Union, Callable, Dict, Optional
 from epics import PV
 
 
+class LazyPV:
+    """Wraps an EPICS PV name and defers connection until first use."""
+
+    __slots__ = ("_pvname", "_pv")
+
+    def __init__(self, pvname: str):
+        object.__setattr__(self, "_pvname", pvname)
+        object.__setattr__(self, "_pv", None)
+
+    @property
+    def pvname(self) -> str:
+        return self._pvname
+
+    def _ensure_connected(self) -> PV:
+        if self._pv is None:
+            object.__setattr__(self, "_pv", PV(self._pvname))
+        return self._pv
+
+    def get(self, *args, **kwargs):
+        return self._ensure_connected().get(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self._ensure_connected().put(*args, **kwargs)
+
+    def get_ctrlvars(self, *args, **kwargs):
+        return self._ensure_connected().get_ctrlvars(*args, **kwargs)
+
+    def add_callback(self, *args, **kwargs):
+        return self._ensure_connected().add_callback(*args, **kwargs)
+
+    def remove_callback(self, *args, **kwargs):
+        return self._ensure_connected().remove_callback(*args, **kwargs)
+
+    def __repr__(self):
+        connected = self._pv is not None
+        return f"LazyPV({self._pvname!r}, connected={connected})"
+
+
 class PVSet(slac_devices.BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -12,13 +50,13 @@ class PVSet(slac_devices.BaseModel):
     )
 
     @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
+    def validate_pv_fields(cls, v: str) -> LazyPV:
         if v is None:
             return None
-        return PV(v)
+        return LazyPV(v)
 
     @field_serializer("*", when_used="unless-none")
-    def serialize_pv_fields(self, v: PV, _info) -> str:
+    def serialize_pv_fields(self, v: LazyPV, _info) -> str:
         return v.pvname
 
 

--- a/slac_devices/lblm.py
+++ b/slac_devices/lblm.py
@@ -131,8 +131,9 @@ class LBLMCollection(BaseModel):
     @field_validator("lblms", mode="before")
     def validate_lblms(cls, v) -> Dict[str, LBLM]:
         for name, lblm in v.items():
+            if isinstance(lblm, LBLM):
+                continue
             lblm = dict(lblm)
-            # Set name field for LBLM
             lblm.update({"name": name})
             v.update({name: lblm})
         return v

--- a/slac_devices/pmt.py
+++ b/slac_devices/pmt.py
@@ -66,8 +66,9 @@ class PMTCollection(BaseModel):
     @field_validator("pmts", mode="before")
     def validate_pmts(cls, v) -> Dict[str, PMT]:
         for name, pmt in v.items():
+            if isinstance(pmt, PMT):
+                continue
             pmt = dict(pmt)
-            # Set name field for PMT
             pmt.update({"name": name})
             v.update({name: pmt})
         return v

--- a/slac_devices/reader.py
+++ b/slac_devices/reader.py
@@ -1,6 +1,4 @@
-import os
-import yaml
-from typing import Union, Optional, Any, Dict
+from typing import Union, Optional
 from pydantic import ValidationError
 import slac_db
 from slac_devices.screen import Screen, ScreenCollection
@@ -113,7 +111,9 @@ def create_bpm(area: str = None, name: str = None) -> Union[None, BPM, BPMCollec
         return BPMCollection(**device_data)
 
 
-def create_tcav(area: str = None, name: str = None) -> Union[None, TCAV, TCAVCollection]:
+def create_tcav(
+    area: str = None, name: str = None
+) -> Union[None, TCAV, TCAVCollection]:
     device_data = slac_db.get_device(area=area, device_type="tcavs", name=name)
     if not device_data:
         return None
@@ -144,7 +144,9 @@ def create_pmt(area: str = None, name: str = None) -> Union[None, PMT]:
         return PMTCollection(**device_data)
 
 
-def create_area(area: str = None) -> Union[None, Area]:
+def create_area(
+    area: str = None, device_types: Optional[set] = None
+) -> Union[None, Area]:
     """
     Constructs an Area object from YAML device configuration data.
 
@@ -156,6 +158,8 @@ def create_area(area: str = None) -> Union[None, Area]:
     Parameters:
         area (str): The name of the area to load. Must match a valid YAML file
                     containing device definitions.
+        device_types (set, optional): Device types to include (e.g. {"bpms", "magnets"}).
+                    If None, all supported types are included.
 
     Returns:
         Area: An Area object with all valid devices instantiated.
@@ -165,12 +169,14 @@ def create_area(area: str = None) -> Union[None, Area]:
     if not yaml_data:
         return None
 
+    allowed = device_types if device_types is not None else _AREA_SUPPORTED_DEVICE_TYPES
+
     filtered_yaml_data = {}
     for device_type, device_payload in yaml_data.items():
+        if device_type not in allowed:
+            continue
         if device_type not in _AREA_SUPPORTED_DEVICE_TYPES:
-            print(
-                f"Skipping unsupported device type {device_type} in area {area}."
-            )
+            print(f"Skipping unsupported device type {device_type} in area {area}.")
             continue
         filtered_yaml_data[device_type] = device_payload
 
@@ -180,7 +186,10 @@ def create_area(area: str = None) -> Union[None, Area]:
         print("Error trying to create area", area, " : ", field_error)
         return None
 
-def create_beampath(beampath: str = None) -> Union[None, Beampath]:
+
+def create_beampath(
+    beampath: str = None, device_types: Optional[set] = None
+) -> Union[None, Beampath]:
     """
     Constructs a Beampath object from a YAML configuration file.
 
@@ -193,6 +202,8 @@ def create_beampath(beampath: str = None) -> Union[None, Beampath]:
     Parameters:
         beampath (str): The name of the beampath to load. Must exist as a key
                         in the beampaths.yaml file.
+        device_types (set, optional): Device types to include (e.g. {"bpms"}).
+                    If None, all supported types are included.
 
     Returns:
         Beampath: A Beampath object containing all valid Area instances.
@@ -202,7 +213,7 @@ def create_beampath(beampath: str = None) -> Union[None, Beampath]:
     areas = {}
     try:
         for area in areas_to_create:
-            created_area = create_area(area=area)
+            created_area = create_area(area=area, device_types=device_types)
             if created_area:
                 areas[area] = created_area
         return Beampath(name=beampath, **{"areas": areas})

--- a/slac_devices/tcav.py
+++ b/slac_devices/tcav.py
@@ -254,6 +254,8 @@ class TCAVCollection(BaseModel):
     @field_validator("tcavs", mode="before")
     def validate_tcavs(cls, v) -> Dict[str, TCAV]:
         for name, tcav in v.items():
+            if isinstance(tcav, TCAV):
+                continue
             tcav = dict(tcav)
             tcav.update({"name": name})
             v.update({name: tcav})

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -105,7 +105,6 @@ class WireMetadata(Metadata):
     detectors: List[str]
     default_detector: str
     tmitloss: Optional[TMITLossBPMs] = None
-    jitter_correction_bpms: Optional[List[str]] = None
     type: str
     wire_type: str
 

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -1,4 +1,3 @@
-
 from pydantic import (
     BaseModel,
     SerializeAsAny,
@@ -97,11 +96,16 @@ class WireControlInformation(ControlInformation):
         super(WireControlInformation, self).__init__(*args, **kwargs)
 
 
+class TMITLossBPMs(BaseModel):
+    upstream: List[str]
+    downstream: List[str]
+
+
 class WireMetadata(Metadata):
     detectors: List[str]
     default_detector: str
-    bpms_before_wire: Optional[List[str]] = None
-    bpms_after_wire: Optional[List[str]] = None
+    tmitloss: Optional[TMITLossBPMs] = None
+    jitter_correction_bpms: Optional[List[str]] = None
     type: str
     wire_type: str
 
@@ -128,11 +132,7 @@ class Wire(Device):
             pass
 
         planes_str = ", ".join(planes) if planes else "no planes configured"
-        return (
-            f"Wire(name={self.name!r}, "
-            f"area={self.area!r}, "
-            f"planes={planes_str})"
-        )
+        return f"Wire(name={self.name!r}, area={self.area!r}, planes={planes_str})"
 
     def __repr__(self) -> str:
         """Return the display string for this wire."""
@@ -228,9 +228,7 @@ class Wire(Device):
         return self.controls_information.PVs.on_status.get()
 
     def position_buffer(self, buffer):
-        return buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:POSN"
-            )
+        return buffer.get_data_buffer(f"{self.controls_information.control_name}:POSN")
 
     def retract(self):
         """Retracts the wire scanner"""
@@ -300,7 +298,7 @@ class Wire(Device):
     def torque_enable(self):
         """Returns the state of the motor torque enable."""
         return self.controls_information.PVs.torque_enable.get()
-    
+
     @torque_enable.setter
     def torque_enable(self, val: bool) -> None:
         validate_boolean(val)
@@ -456,10 +454,7 @@ class Wire(Device):
             self.validate_range_speed(plane, inner, outer)
         except ValueError as exc:
             warnings.warn(
-                (
-                    f"{self.name} {plane.upper()} range configuration is invalid: "
-                    f"{exc}"
-                ),
+                (f"{self.name} {plane.upper()} range configuration is invalid: {exc}"),
                 UserWarning,
                 stacklevel=2,
             )
@@ -485,12 +480,8 @@ class Wire(Device):
         """Set both range endpoints before running configuration validation."""
         plane = validate_plane(plane)
         validate_range(val)
-        getattr(self.controls_information.PVs, f"{plane}_wire_inner").put(
-            value=val[0]
-        )
-        getattr(self.controls_information.PVs, f"{plane}_wire_outer").put(
-            value=val[1]
-        )
+        getattr(self.controls_information.PVs, f"{plane}_wire_inner").put(value=val[0])
+        getattr(self.controls_information.PVs, f"{plane}_wire_outer").put(value=val[1])
         self._warn_invalid_range_configuration(plane, val[0], val[1])
 
     def calculate_required_speed(self, plane: str, inner: int, outer: int) -> float:

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -556,8 +556,9 @@ class WireCollection(BaseModel):
     @field_validator("wires", mode="before")
     def validate_wires(cls, v) -> Dict[str, Wire]:
         for name, wire in v.items():
+            if isinstance(wire, Wire):
+                continue
             wire = dict(wire)
-            # Set name field for wire
             wire.update({"name": name})
             v.update({name: wire})
         return v


### PR DESCRIPTION
This pull request introduces a new structure for BPM configuration related to TMIT loss in wire devices, and makes several code style and formatting improvements throughout the `slac_devices/wire.py` file. It also adds a pre-commit configuration to enforce code quality and consistency.

**Configuration and Structure Improvements:**

* Added a new `TMITLossBPMs` model to represent upstream and downstream BPMs, and updated the `WireMetadata` class to use a new optional `tmitloss` field of this type instead of the previous `bpms_before_wire` and `bpms_after_wire` fields.

**Code Formatting and Style:**

* Refactored several function calls and string formatting in `slac_devices/wire.py` to improve readability and maintain PEP8 compliance, including single-line formatting for return statements and warnings.
* Removed an unnecessary blank line at the top of `slac_devices/wire.py` for cleaner imports.

**Tooling:**

* Added a `.pre-commit-config.yaml` file to set up pre-commit hooks for code formatting, linting, and checking for common issues, including integration with Ruff for Python linting and formatting.