### PR TITLE
Add LazyPV to defer EPICS channel access until first use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -7,11 +7,9 @@ from epics import PV
 class LazyPV:
     """Wraps an EPICS PV name and defers connection until first use."""
 
-    __slots__ = ("_pvname", "_pv")
-
     def __init__(self, pvname: str):
-        object.__setattr__(self, "_pvname", pvname)
-        object.__setattr__(self, "_pv", None)
+        self._pvname = pvname
+        self._pv = None
 
     @property
     def pvname(self) -> str:
@@ -46,7 +44,7 @@ class LazyPV:
         return hash(self._pvname)
 
     def __repr__(self):
-        connected = self._pv is not None
+        connected = self._pv.connected if self._pv else False
         return f"LazyPV({self._pvname!r}, connected={connected})"
 
 

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -4,6 +4,52 @@ from typing import List, Union, Callable, Dict, Optional
 from epics import PV
 
 
+class LazyPV:
+    """Wraps an EPICS PV name and defers connection until first use."""
+
+    __slots__ = ("_pvname", "_pv")
+
+    def __init__(self, pvname: str):
+        object.__setattr__(self, "_pvname", pvname)
+        object.__setattr__(self, "_pv", None)
+
+    @property
+    def pvname(self) -> str:
+        return self._pvname
+
+    def _ensure_connected(self) -> PV:
+        if self._pv is None:
+            object.__setattr__(self, "_pv", PV(self._pvname))
+        return self._pv
+
+    def get(self, *args, **kwargs):
+        return self._ensure_connected().get(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self._ensure_connected().put(*args, **kwargs)
+
+    def get_ctrlvars(self, *args, **kwargs):
+        return self._ensure_connected().get_ctrlvars(*args, **kwargs)
+
+    def add_callback(self, *args, **kwargs):
+        return self._ensure_connected().add_callback(*args, **kwargs)
+
+    def remove_callback(self, *args, **kwargs):
+        return self._ensure_connected().remove_callback(*args, **kwargs)
+
+    def __eq__(self, other):
+        if isinstance(other, LazyPV):
+            return self._pvname == other._pvname
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self._pvname)
+
+    def __repr__(self):
+        connected = self._pv is not None
+        return f"LazyPV({self._pvname!r}, connected={connected})"
+
+
 class PVSet(slac_devices.BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -11,14 +57,16 @@ class PVSet(slac_devices.BaseModel):
         frozen=True,
     )
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
+    @field_validator("*", mode="wrap")
+    def validate_pv_fields(cls, v, handler) -> LazyPV:
         if v is None:
             return None
-        return PV(v)
+        if isinstance(v, LazyPV):
+            return v
+        return LazyPV(v)
 
     @field_serializer("*", when_used="unless-none")
-    def serialize_pv_fields(self, v: PV, _info) -> str:
+    def serialize_pv_fields(self, v: LazyPV, _info) -> str:
         return v.pvname
 
 

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -17,7 +17,7 @@ class LazyPV:
 
     def _ensure_connected(self) -> PV:
         if self._pv is None:
-            object.__setattr__(self, "_pv", PV(self._pvname))
+            self._pv = PV(self._pvname)
         return self._pv
 
     def get(self, *args, **kwargs):


### PR DESCRIPTION
`PVSet` previously created `epics.PV` objects eagerly during device validation, sending CA search requests for every PV field on every device. When instantiating a full Beampath (hundreds of devices), this saturated the CA search queue and caused subsequent caget calls to time out.

`LazyPV` stores the PV name string and only creates the underlying `epics.PV` connection on first `.get()`, `.put()`, or `.add_callback()` call. The `.pvname` property returns the string immediately without connecting.

Addresses #22 