### PR TITLE
Refactor device validation to skip existing instances and update BPM buffer methods

### DIFF
--- a/slac_devices/area.py
+++ b/slac_devices/area.py
@@ -63,13 +63,13 @@ def _prune_invalid_devices(
         payload_copy = dict(payload)
         payload_copy["name"] = name
         try:
-            device_class(**payload_copy)
+            device = device_class(**payload_copy)
         except (ValidationError, TypeError, Exception) as field_error:
             print(
                 f"Skipping invalid {device_type} {name} in {area_name}: {field_error}"
             )
             continue
-        valid_devices[name] = payload_copy
+        valid_devices[name] = device
 
     if not valid_devices:
         return None
@@ -212,7 +212,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_magnets:
             return None
-        return MagnetCollection(magnets=valid_magnets)
+        return MagnetCollection.model_construct(devices=valid_magnets)
 
     @field_validator(
         "screen_collection",
@@ -227,7 +227,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_screens:
             return None
-        return ScreenCollection(screens=valid_screens)
+        return ScreenCollection.model_construct(devices=valid_screens)
 
     @field_validator(
         "wire_collection",
@@ -242,7 +242,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_wires:
             return None
-        return WireCollection(wires=valid_wires)
+        return WireCollection.model_construct(wires=valid_wires)
 
     @field_validator(
         "bpm_collection",
@@ -257,7 +257,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_bpms:
             return None
-        return BPMCollection(bpms=valid_bpms)
+        return BPMCollection.model_construct(bpms=valid_bpms)
 
     @field_validator(
         "lblm_collection",
@@ -272,7 +272,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_lblms:
             return None
-        return LBLMCollection(lblms=valid_lblms)
+        return LBLMCollection.model_construct(lblms=valid_lblms)
 
     @field_validator(
         "pmt_collection",
@@ -287,7 +287,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_pmts:
             return None
-        return PMTCollection(pmts=valid_pmts)
+        return PMTCollection.model_construct(pmts=valid_pmts)
 
     @field_validator(
         "tcav_collection",
@@ -302,7 +302,7 @@ class Area(slac_devices.BaseModel):
         )
         if not valid_tcavs:
             return None
-        return TCAVCollection(tcavs=valid_tcavs)
+        return TCAVCollection.model_construct(tcavs=valid_tcavs)
 
     @property
     def magnets(

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -76,7 +76,7 @@ class BPM(Device):
 
     def tmit_buffer(self, buffer):
         """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get_data_buffer(self.controls_information.PVs.tmit.pvname)
+        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:TMIT")
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -88,8 +88,9 @@ class BPMCollection(BaseModel):
     @field_validator("bpms", mode="before")
     def validate_bpms(cls, v) -> Dict[str, BPM]:
         for name, bpm in v.items():
+            if isinstance(bpm, BPM):
+                continue
             bpm = dict(bpm)
-            # Set name field for BPM
             bpm.update({"name": name})
             v.update({name: bpm})
         return v

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -58,7 +58,10 @@ class BPM(Device):
 
     def x_buffer(self, buffer):
         """Retrieve TMIT signal data from timing buffer"""
-        return buffer.get_buffer_data(self.controls_information.PVs.x)
+        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:X")
+        if data is None:
+            raise BufferError("No data in buffer or PV not found")
+        return data
 
     @property
     def y(self):
@@ -67,7 +70,10 @@ class BPM(Device):
 
     def y_buffer(self, buffer):
         """Retrieve TMIT signal data from timing buffer"""
-        return buffer.get_buffer_data(self.controls_information.PVs.y)
+        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:Y")
+        if data is None:
+            raise BufferError("No data in buffer or PV not found")
+        return data
 
     @property
     def tmit(self):
@@ -94,6 +100,39 @@ class BPMCollection(BaseModel):
             bpm.update({"name": name})
             v.update({name: bpm})
         return v
+
+    def get_buffer_data(
+        self, buffer, suffix: str = "TMIT"
+    ) -> Dict[str, Optional[list]]:
+        """Retrieve buffer data for all BPMs in the collection.
+
+        Args:
+            buffer: An edef EventDefinition or BSABuffer object.
+            suffix: PV suffix to read (e.g. "TMIT", "X", "Y").
+
+        Returns:
+            Dict mapping BPM name to data array, or None for unreachable BPMs.
+        """
+        pv_names = [
+            f"{bpm.controls_information.control_name}:{suffix}"
+            for bpm in self.bpms.values()
+        ]
+        try:
+            buff_data = buffer.get_buffer(pv_names)
+            return {
+                name: buff_data.get(f"{bpm.controls_information.control_name}:{suffix}")
+                for name, bpm in self.bpms.items()
+            }
+        except (TypeError, Exception):
+            results = {}
+            for name, bpm in self.bpms.items():
+                try:
+                    results[name] = buffer.get_data_buffer(
+                        f"{bpm.controls_information.control_name}:{suffix}"
+                    )
+                except (TypeError, BufferError):
+                    results[name] = None
+            return results
 
     def _make_bpm_names_list_from_args(
         self, args: Union[str, List[str], None]

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -113,26 +113,17 @@ class BPMCollection(BaseModel):
         Returns:
             Dict mapping BPM name to data array, or None for unreachable BPMs.
         """
-        pv_names = [
-            f"{bpm.controls_information.control_name}:{suffix}"
-            for bpm in self.bpms.values()
-        ]
-        try:
-            buff_data = buffer.get_buffer(pv_names)
-            return {
-                name: buff_data.get(f"{bpm.controls_information.control_name}:{suffix}")
-                for name, bpm in self.bpms.items()
-            }
-        except (TypeError, Exception):
-            results = {}
+
+        def _yield_buffer_data():
             for name, bpm in self.bpms.items():
+                address = f"{bpm.controls_information.control_name}:{suffix}"
                 try:
-                    results[name] = buffer.get_data_buffer(
-                        f"{bpm.controls_information.control_name}:{suffix}"
-                    )
+                    data = buffer.get_data_buffer(address)
                 except (TypeError, BufferError):
-                    results[name] = None
-            return results
+                    data = None
+                yield name, data
+
+        return dict(_yield_buffer_data())
 
     def _make_bpm_names_list_from_args(
         self, args: Union[str, List[str], None]

--- a/slac_devices/device.py
+++ b/slac_devices/device.py
@@ -252,6 +252,8 @@ class DeviceCollection(slac_devices.BaseModel):
         and then use that dictionary to create each Device.
         """
         for name, device in v.items():
+            if isinstance(device, Device):
+                continue
             device = dict(device)
             device.update({"name": name})
             v.update({name: device})

--- a/slac_devices/lblm.py
+++ b/slac_devices/lblm.py
@@ -131,8 +131,9 @@ class LBLMCollection(BaseModel):
     @field_validator("lblms", mode="before")
     def validate_lblms(cls, v) -> Dict[str, LBLM]:
         for name, lblm in v.items():
+            if isinstance(lblm, LBLM):
+                continue
             lblm = dict(lblm)
-            # Set name field for LBLM
             lblm.update({"name": name})
             v.update({name: lblm})
         return v

--- a/slac_devices/pmt.py
+++ b/slac_devices/pmt.py
@@ -66,8 +66,9 @@ class PMTCollection(BaseModel):
     @field_validator("pmts", mode="before")
     def validate_pmts(cls, v) -> Dict[str, PMT]:
         for name, pmt in v.items():
+            if isinstance(pmt, PMT):
+                continue
             pmt = dict(pmt)
-            # Set name field for PMT
             pmt.update({"name": name})
             v.update({name: pmt})
         return v

--- a/slac_devices/tcav.py
+++ b/slac_devices/tcav.py
@@ -254,6 +254,8 @@ class TCAVCollection(BaseModel):
     @field_validator("tcavs", mode="before")
     def validate_tcavs(cls, v) -> Dict[str, TCAV]:
         for name, tcav in v.items():
+            if isinstance(tcav, TCAV):
+                continue
             tcav = dict(tcav)
             tcav.update({"name": name})
             v.update({name: tcav})

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -1,4 +1,3 @@
-
 from pydantic import (
     BaseModel,
     SerializeAsAny,
@@ -128,11 +127,7 @@ class Wire(Device):
             pass
 
         planes_str = ", ".join(planes) if planes else "no planes configured"
-        return (
-            f"Wire(name={self.name!r}, "
-            f"area={self.area!r}, "
-            f"planes={planes_str})"
-        )
+        return f"Wire(name={self.name!r}, area={self.area!r}, planes={planes_str})"
 
     def __repr__(self) -> str:
         """Return the display string for this wire."""
@@ -228,9 +223,7 @@ class Wire(Device):
         return self.controls_information.PVs.on_status.get()
 
     def position_buffer(self, buffer):
-        return buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:POSN"
-            )
+        return buffer.get_data_buffer(f"{self.controls_information.control_name}:POSN")
 
     def retract(self):
         """Retracts the wire scanner"""
@@ -300,7 +293,7 @@ class Wire(Device):
     def torque_enable(self):
         """Returns the state of the motor torque enable."""
         return self.controls_information.PVs.torque_enable.get()
-    
+
     @torque_enable.setter
     def torque_enable(self, val: bool) -> None:
         validate_boolean(val)
@@ -456,10 +449,7 @@ class Wire(Device):
             self.validate_range_speed(plane, inner, outer)
         except ValueError as exc:
             warnings.warn(
-                (
-                    f"{self.name} {plane.upper()} range configuration is invalid: "
-                    f"{exc}"
-                ),
+                (f"{self.name} {plane.upper()} range configuration is invalid: {exc}"),
                 UserWarning,
                 stacklevel=2,
             )
@@ -485,12 +475,8 @@ class Wire(Device):
         """Set both range endpoints before running configuration validation."""
         plane = validate_plane(plane)
         validate_range(val)
-        getattr(self.controls_information.PVs, f"{plane}_wire_inner").put(
-            value=val[0]
-        )
-        getattr(self.controls_information.PVs, f"{plane}_wire_outer").put(
-            value=val[1]
-        )
+        getattr(self.controls_information.PVs, f"{plane}_wire_inner").put(value=val[0])
+        getattr(self.controls_information.PVs, f"{plane}_wire_outer").put(value=val[1])
         self._warn_invalid_range_configuration(plane, val[0], val[1])
 
     def calculate_required_speed(self, plane: str, inner: int, outer: int) -> float:
@@ -566,8 +552,9 @@ class WireCollection(BaseModel):
     @field_validator("wires", mode="before")
     def validate_wires(cls, v) -> Dict[str, Wire]:
         for name, wire in v.items():
+            if isinstance(wire, Wire):
+                continue
             wire = dict(wire)
-            # Set name field for wire
             wire.update({"name": name})
             v.update({name: wire})
         return v


### PR DESCRIPTION
This pull request improves device validation and collection handling across several device types, with a focus on ensuring that objects are not redundantly re-validated or re-constructed if they are already of the correct type. It also standardizes and simplifies some method implementations and string formatting, and makes minor bug fixes to PV name usage.

**Device validation and collection improvements:**

* Updated all device collection validators (for BPM, LBLM, PMT, TCAV, Wire) to check if an item is already an instance of the correct class before attempting to convert or update it, preventing unnecessary re-instantiation. 
* In area validation functions (e.g., `validate_magnets`, `validate_screens`, etc.), replaced direct construction of collection objects with `model_construct`, which is more appropriate for Pydantic models in this context. 
* In `_prune_invalid_devices`, now stores the constructed device object (rather than the input payload) in the result, ensuring type consistency.

**Device validation and collection construction improvements:**

* Updated validators in device collection classes (`BPMCollection`, `LBLMCollection`, `PMTCollection`, `TCAVCollection`, `WireCollection`) to skip conversion if the item is already an instance, preventing unnecessary re-instantiation. 
* Changed device collection construction in `area.py` validators to use `.model_construct()` for consistency and efficiency, rather than direct instantiation.

**BPM buffer data retrieval enhancements:**

* Refactored `BPM` buffer methods to use explicit PV name construction and added error handling for missing data. 
* Added a `get_buffer_data` method to `BPMCollection` to retrieve buffer data for all BPMs at once, with fallback and error handling. 

**Wire device code cleanup:**

* Simplified string formatting and method calls for better readability and maintainability in `wire.py`. 
* Removed an unnecessary blank line at the top of `wire.py`. 

**Device pruning logic:**

* In `_prune_invalid_devices`, now stores validated device instances rather than raw payloads, ensuring type correctness in the resulting dictionary. 

**Bug fixes and code correctness:**

* Fixed a bug in `BPM.tmit_buffer` to use the correct PV name format for retrieving TMIT signal data.

**Code style and formatting:**

* Simplified and standardized string formatting and multi-line expressions in `Wire` methods and warnings for improved readability.
* Removed an unnecessary blank line at the start of `slac_devices/wire.py`.