### PR TITLE
Added Create Device Function

### DIFF
--- a/slac_devices/reader.py
+++ b/slac_devices/reader.py
@@ -3,6 +3,7 @@ import yaml
 from typing import Union, Optional, Any, Dict
 from pydantic import ValidationError
 import slac_db
+import slac_db.db_to_yaml
 from slac_devices.screen import Screen, ScreenCollection
 from slac_devices.magnet import Magnet, MagnetCollection
 from slac_devices.wire import Wire, WireCollection
@@ -24,6 +25,28 @@ _AREA_SUPPORTED_DEVICE_TYPES = {
     "tcavs",
 }
 
+_CONSTRUCTOR_MAP = {
+    "magnets": Magnet,
+    "screens": Screen,
+    "wires": Wire,
+    "bpms": BPM,
+    "lblms": LBLM,
+    "pmts": PMT,
+    "tcavs": TCAV,
+}
+
+def create_device(name):
+    data = slac_db.db_to_yaml.get_device(name)
+    if data is None:
+        print(f"Unrecognized device type for device={name}")
+        return None
+    device_type = data.pop("yaml_type")
+    constructor = _CONSTRUCTOR_MAP[device_type]
+    try:
+        return constructor(**data)
+    except ValidationError as field_error:
+        print(field_error)
+        return None
 
 def create_magnet(
     area: str = None, name: str = None

--- a/slac_devices/reader.py
+++ b/slac_devices/reader.py
@@ -38,7 +38,7 @@ _CONSTRUCTOR_MAP = {
 def create_device(name):
     data = slac_db.db_to_yaml.get_device(name)
     if data is None:
-        print(f"Unrecognized device type for device={name}")
+        print(f"Unrecognized name for device={name}")
         return None
     device_type = data.pop("yaml_type")
     constructor = _CONSTRUCTOR_MAP[device_type]

--- a/slac_devices/tcav.py
+++ b/slac_devices/tcav.py
@@ -47,9 +47,9 @@ class TCAVControlInformation(ControlInformation):
             TimeoutError: If any PV fails to return its control variables.
         """
         _ = __context  # avoid linter warning for unused variable
-        self.set_mode_config_option()
-        self.set_amplitude_feedback_options()
-        self.setup_phase_feedback_option()
+        # self.set_mode_config_option()
+        # self.set_amplitude_feedback_options()
+        # self.setup_phase_feedback_option()
 
     def set_mode_config_option(self):
         """

--- a/slac_devices/tcav.py
+++ b/slac_devices/tcav.py
@@ -47,9 +47,9 @@ class TCAVControlInformation(ControlInformation):
             TimeoutError: If any PV fails to return its control variables.
         """
         _ = __context  # avoid linter warning for unused variable
-        # self.set_mode_config_option()
-        # self.set_amplitude_feedback_options()
-        # self.setup_phase_feedback_option()
+        self.set_mode_config_option()
+        self.set_amplitude_feedback_options()
+        self.setup_phase_feedback_option()
 
     def set_mode_config_option(self):
         """


### PR DESCRIPTION
Normally we create devices by pulling from the area they belong to. But device names are unique across areas, so this isn't necessary. This PR introduces a function that can create a device object from its MAD name alone.