### PR TITLE
Add optional jitter_bpms field to WireMetadata class

### DIFF
--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -105,6 +105,7 @@ class WireMetadata(Metadata):
     detectors: List[str]
     default_detector: str
     tmitloss: Optional[TMITLossBPMs] = None
+    jitter_bpms: Optional[List[str]] = None
     type: str
     wire_type: str
 


### PR DESCRIPTION
This pull request introduces a small update to the `WireMetadata` class in `slac_devices/wire.py`, adding an optional `jitter_bpms` field to support additional metadata.

- Added an optional `jitter_bpms` field (a list of strings) to the `WireMetadata` class to allow specifying BPMs relevant for jitter analysis.