### PR TITLE
Refactor buffer retrieval methods in BPM, LBLM, PMT, and Wire classes

### DIFF
--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -57,36 +57,27 @@ class BPM(Device):
         """Get TMIT value"""
         return self.controls_information.PVs.x.get()
 
-    def x_buffer(self, buffer, **kwargs):
+    def x_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve X signal data from timing buffer"""
-        data = buffer.get(f"{self.controls_information.control_name}:X", **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(f"{self.controls_information.control_name}:X", **kwargs)
 
     @property
     def y(self):
         """Get TMIT value"""
         return self.controls_information.PVs.y.get()
 
-    def y_buffer(self, buffer, **kwargs):
+    def y_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve Y signal data from timing buffer"""
-        data = buffer.get(f"{self.controls_information.control_name}:Y", **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(f"{self.controls_information.control_name}:Y", **kwargs)
 
     @property
     def tmit(self):
         """Get TMIT value"""
         return self.controls_information.PVs.tmit.get()
 
-    def tmit_buffer(self, buffer, **kwargs):
+    def tmit_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get(f"{self.controls_information.control_name}:TMIT", **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(f"{self.controls_information.control_name}:TMIT", **kwargs)
 
 
 class BPMCollection(BaseModel):

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -58,9 +58,7 @@ class BPM(Device):
 
     def x_buffer(self, buffer, **kwargs):
         """Retrieve X signal data from timing buffer"""
-        data = buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:X", **kwargs
-        )
+        data = buffer.get(f"{self.controls_information.control_name}:X", **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -72,9 +70,7 @@ class BPM(Device):
 
     def y_buffer(self, buffer, **kwargs):
         """Retrieve Y signal data from timing buffer"""
-        data = buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:Y", **kwargs
-        )
+        data = buffer.get(f"{self.controls_information.control_name}:Y", **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -86,9 +82,7 @@ class BPM(Device):
 
     def tmit_buffer(self, buffer, **kwargs):
         """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:TMIT", **kwargs
-        )
+        data = buffer.get(f"{self.controls_information.control_name}:TMIT", **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -115,7 +109,7 @@ class BPMCollection(BaseModel):
         Args:
             buffer: An edef EventDefinition or BSABuffer object.
             suffix: PV suffix to read (e.g. "TMIT", "X", "Y").
-            **kwargs: Passed to buffer.get_data_buffer() (e.g. pad, retries).
+            **kwargs: Passed to buffer.get() (e.g. pad, retries).
 
         Returns:
             Dict mapping BPM name to data array, or None for unreachable BPMs.
@@ -125,7 +119,7 @@ class BPMCollection(BaseModel):
             for name, bpm in self.bpms.items():
                 address = f"{bpm.controls_information.control_name}:{suffix}"
                 try:
-                    data = buffer.get_data_buffer(address, **kwargs)
+                    data = buffer.get(address, **kwargs)
                 except (TypeError, BufferError):
                     data = None
                 yield name, data

--- a/slac_devices/bpm.py
+++ b/slac_devices/bpm.py
@@ -56,9 +56,11 @@ class BPM(Device):
         """Get TMIT value"""
         return self.controls_information.PVs.x.get()
 
-    def x_buffer(self, buffer):
-        """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:X")
+    def x_buffer(self, buffer, **kwargs):
+        """Retrieve X signal data from timing buffer"""
+        data = buffer.get_data_buffer(
+            f"{self.controls_information.control_name}:X", **kwargs
+        )
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -68,9 +70,11 @@ class BPM(Device):
         """Get TMIT value"""
         return self.controls_information.PVs.y.get()
 
-    def y_buffer(self, buffer):
-        """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:Y")
+    def y_buffer(self, buffer, **kwargs):
+        """Retrieve Y signal data from timing buffer"""
+        data = buffer.get_data_buffer(
+            f"{self.controls_information.control_name}:Y", **kwargs
+        )
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -80,9 +84,11 @@ class BPM(Device):
         """Get TMIT value"""
         return self.controls_information.PVs.tmit.get()
 
-    def tmit_buffer(self, buffer):
+    def tmit_buffer(self, buffer, **kwargs):
         """Retrieve TMIT signal data from timing buffer"""
-        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:TMIT")
+        data = buffer.get_data_buffer(
+            f"{self.controls_information.control_name}:TMIT", **kwargs
+        )
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -102,13 +108,14 @@ class BPMCollection(BaseModel):
         return v
 
     def get_buffer_data(
-        self, buffer, suffix: str = "TMIT"
+        self, buffer, suffix: str = "TMIT", **kwargs
     ) -> Dict[str, Optional[list]]:
         """Retrieve buffer data for all BPMs in the collection.
 
         Args:
             buffer: An edef EventDefinition or BSABuffer object.
             suffix: PV suffix to read (e.g. "TMIT", "X", "Y").
+            **kwargs: Passed to buffer.get_data_buffer() (e.g. pad, retries).
 
         Returns:
             Dict mapping BPM name to data array, or None for unreachable BPMs.
@@ -118,7 +125,7 @@ class BPMCollection(BaseModel):
             for name, bpm in self.bpms.items():
                 address = f"{bpm.controls_information.control_name}:{suffix}"
                 try:
-                    data = buffer.get_data_buffer(address)
+                    data = buffer.get_data_buffer(address, **kwargs)
                 except (TypeError, BufferError):
                     data = None
                 yield name, data

--- a/slac_devices/lblm.py
+++ b/slac_devices/lblm.py
@@ -66,12 +66,9 @@ class LBLM(Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def fast_buffer(self, buffer, **kwargs):
+    def fast_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve fast signal data from timing buffer"""
-        data = buffer.get(f"{self.controls_information.control_name}:FAST", **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(f"{self.controls_information.control_name}:FAST", **kwargs)
 
     @property
     def i0_loss(self):
@@ -109,19 +106,13 @@ class LBLM(Device):
         except ValidationError as e:
             print("Bypass must be a boolean:", e)
 
-    def i0_loss_buffer(self, buffer, **kwargs):
+    def i0_loss_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve I0 Loss data from timing buffer"""
-        data = buffer.get(self.controls_information.PVs.i0_loss.pvname, **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(self.controls_information.PVs.i0_loss.pvname, **kwargs)
 
-    def gated_integral_buffer(self, buffer, **kwargs):
+    def gated_integral_buffer(self, buffer: Buffer, **kwargs):
         """Get Gated Integral data from timing buffer"""
-        data = buffer.get(self.controls_information.PVs.gated_integral.pvname, **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(self.controls_information.PVs.gated_integral.pvname, **kwargs)
 
 
 class LBLMCollection(BaseModel):

--- a/slac_devices/lblm.py
+++ b/slac_devices/lblm.py
@@ -67,9 +67,7 @@ class LBLM(Device):
 
     def fast_buffer(self, buffer, **kwargs):
         """Retrieve fast signal data from timing buffer"""
-        data = buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:FAST", **kwargs
-        )
+        data = buffer.get(f"{self.controls_information.control_name}:FAST", **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -112,18 +110,14 @@ class LBLM(Device):
 
     def i0_loss_buffer(self, buffer, **kwargs):
         """Retrieve I0 Loss data from timing buffer"""
-        data = buffer.get_data_buffer(
-            self.controls_information.PVs.i0_loss.pvname, **kwargs
-        )
+        data = buffer.get(self.controls_information.PVs.i0_loss.pvname, **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
 
     def gated_integral_buffer(self, buffer, **kwargs):
         """Get Gated Integral data from timing buffer"""
-        data = buffer.get_data_buffer(
-            self.controls_information.PVs.gated_integral.pvname, **kwargs
-        )
+        data = buffer.get(self.controls_information.PVs.gated_integral.pvname, **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data

--- a/slac_devices/lblm.py
+++ b/slac_devices/lblm.py
@@ -65,9 +65,11 @@ class LBLM(Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def fast_buffer(self, buffer):
+    def fast_buffer(self, buffer, **kwargs):
         """Retrieve fast signal data from timing buffer"""
-        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:FAST")
+        data = buffer.get_data_buffer(
+            f"{self.controls_information.control_name}:FAST", **kwargs
+        )
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -108,17 +110,19 @@ class LBLM(Device):
         except ValidationError as e:
             print("Bypass must be a boolean:", e)
 
-    def i0_loss_buffer(self, buffer):
+    def i0_loss_buffer(self, buffer, **kwargs):
         """Retrieve I0 Loss data from timing buffer"""
-        data = buffer.get_data_buffer(self.controls_information.PVs.i0_loss.pvname)
+        data = buffer.get_data_buffer(
+            self.controls_information.PVs.i0_loss.pvname, **kwargs
+        )
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
 
-    def gated_integral_buffer(self, buffer):
+    def gated_integral_buffer(self, buffer, **kwargs):
         """Get Gated Integral data from timing buffer"""
         data = buffer.get_data_buffer(
-            self.controls_information.PVs.gated_integral.pvname
+            self.controls_information.PVs.gated_integral.pvname, **kwargs
         )
         if data is None:
             raise BufferError("No data in buffer or PV not found")

--- a/slac_devices/pmt.py
+++ b/slac_devices/pmt.py
@@ -46,12 +46,9 @@ class PMT(Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def qdcraw_buffer(self, buffer, **kwargs):
+    def qdcraw_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve QDCRAW signal data from timing buffer"""
-        data = buffer.get(f"{self.controls_information.control_name}:QDCRAW", **kwargs)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
+        return buffer.get(f"{self.controls_information.control_name}:QDCRAW", **kwargs)
 
     @property
     def qdcraw(self):

--- a/slac_devices/pmt.py
+++ b/slac_devices/pmt.py
@@ -47,9 +47,7 @@ class PMT(Device):
 
     def qdcraw_buffer(self, buffer, **kwargs):
         """Retrieve QDCRAW signal data from timing buffer"""
-        data = buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:QDCRAW", **kwargs
-        )
+        data = buffer.get(f"{self.controls_information.control_name}:QDCRAW", **kwargs)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data

--- a/slac_devices/pmt.py
+++ b/slac_devices/pmt.py
@@ -45,10 +45,10 @@ class PMT(Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def qdcraw_buffer(self, buffer):
+    def qdcraw_buffer(self, buffer, **kwargs):
         """Retrieve QDCRAW signal data from timing buffer"""
         data = buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:QDCRAW"
+            f"{self.controls_information.control_name}:QDCRAW", **kwargs
         )
         if data is None:
             raise BufferError("No data in buffer or PV not found")

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -227,7 +227,7 @@ class Wire(Device):
         """Returns the on status of the wire scanner."""
         return self.controls_information.PVs.on_status.get()
 
-    def position_buffer(self, buffer, **kwargs):
+    def position_buffer(self, buffer: Buffer, **kwargs):
         return buffer.get(f"{self.controls_information.control_name}:POSN", **kwargs)
 
     def retract(self):

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -226,8 +226,10 @@ class Wire(Device):
         """Returns the on status of the wire scanner."""
         return self.controls_information.PVs.on_status.get()
 
-    def position_buffer(self, buffer):
-        return buffer.get_data_buffer(f"{self.controls_information.control_name}:POSN")
+    def position_buffer(self, buffer, **kwargs):
+        return buffer.get_data_buffer(
+            f"{self.controls_information.control_name}:POSN", **kwargs
+        )
 
     def retract(self):
         """Retracts the wire scanner"""

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -227,9 +227,7 @@ class Wire(Device):
         return self.controls_information.PVs.on_status.get()
 
     def position_buffer(self, buffer, **kwargs):
-        return buffer.get_data_buffer(
-            f"{self.controls_information.control_name}:POSN", **kwargs
-        )
+        return buffer.get(f"{self.controls_information.control_name}:POSN", **kwargs)
 
     def retract(self):
         """Retracts the wire scanner"""


### PR DESCRIPTION
This pull request refactors several device classes to standardize and modernize the way buffer data is retrieved. The main change is replacing calls to a custom `get_data_buffer` method with the more general `get` method, while also allowing additional keyword arguments to be passed through. This improves flexibility and consistency across device classes.

**Buffer access refactoring:**

* Updated all buffer data retrieval methods in `BPM`, `LBLM`, `PMT`, and `Wire` device classes to use `buffer.get()` instead of `buffer.get_data_buffer()`, and added `**kwargs` to support additional parameters. This change standardizes buffer access and increases method flexibility.

* Modified the `get_buffer_data` method in the `BPM` collection to accept `**kwargs` and pass them to `buffer.get()`, allowing for more customizable buffer queries.

These changes make the device classes more consistent and extensible when interacting with timing buffers.