### PR TITLE
Add Toroid device support and update WireMetadata for charge toroids

### DIFF
--- a/slac_devices/reader.py
+++ b/slac_devices/reader.py
@@ -9,6 +9,7 @@ from slac_devices.lblm import LBLM, LBLMCollection
 from slac_devices.pmt import PMT, PMTCollection
 from slac_devices.bpm import BPM, BPMCollection
 from slac_devices.tcav import TCAV, TCAVCollection
+from slac_devices.toroid import Toroid
 from slac_devices.area import Area
 from slac_devices.beampath import Beampath
 
@@ -21,6 +22,7 @@ _AREA_SUPPORTED_DEVICE_TYPES = {
     "lblms",
     "pmts",
     "tcavs",
+    "toroids",
 }
 
 _CONSTRUCTOR_MAP = {
@@ -31,7 +33,9 @@ _CONSTRUCTOR_MAP = {
     "lblms": LBLM,
     "pmts": PMT,
     "tcavs": TCAV,
+    "toroids": Toroid,
 }
+
 
 def create_device(name):
     data = slac_db.db_to_yaml.get_device(name)
@@ -45,6 +49,7 @@ def create_device(name):
     except ValidationError as field_error:
         print(field_error)
         return None
+
 
 def create_magnet(
     area: str = None, name: str = None
@@ -165,6 +170,20 @@ def create_pmt(area: str = None, name: str = None) -> Union[None, PMT]:
             return None
     else:
         return PMTCollection(**device_data)
+
+
+def create_toroid(area: str = None, name: str = None) -> Union[None, Toroid]:
+    device_data = slac_db.get_device(area=area, device_type="toroids", name=name)
+    if not device_data:
+        return None
+    if name:
+        try:
+            device_data.update({"name": name})
+            return Toroid(**device_data)
+        except ValidationError as field_error:
+            print(field_error)
+            return None
+    return None
 
 
 def create_area(

--- a/slac_devices/reader.py
+++ b/slac_devices/reader.py
@@ -9,7 +9,7 @@ from slac_devices.lblm import LBLM, LBLMCollection
 from slac_devices.pmt import PMT, PMTCollection
 from slac_devices.bpm import BPM, BPMCollection
 from slac_devices.tcav import TCAV, TCAVCollection
-from slac_devices.toroid import Toroid
+from slac_devices.toroid import Toroid, ToroidCollection
 from slac_devices.area import Area
 from slac_devices.beampath import Beampath
 
@@ -183,7 +183,8 @@ def create_toroid(area: str = None, name: str = None) -> Union[None, Toroid]:
         except ValidationError as field_error:
             print(field_error)
             return None
-    return None
+    else:
+        return ToroidCollection(**device_data)
 
 
 def create_area(

--- a/slac_devices/toroid.py
+++ b/slac_devices/toroid.py
@@ -1,0 +1,41 @@
+from pydantic import SerializeAsAny
+
+from slac_devices.device import Device, PVSet, ControlInformation, Metadata
+from slac_timing import Buffer
+from epics import PV
+
+
+class ToroidPVSet(PVSet):
+    tmit: PV
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ToroidControlInformation(ControlInformation):
+    PVs: SerializeAsAny[ToroidPVSet]
+
+    def __init__(self, *args, **kwargs):
+        super(ToroidControlInformation, self).__init__(*args, **kwargs)
+
+
+class ToroidMetadata(Metadata):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Toroid(Device):
+    controls_information: SerializeAsAny[ToroidControlInformation]
+    metadata: SerializeAsAny[ToroidMetadata]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @property
+    def tmit(self):
+        """Get current TMIT value."""
+        return self.controls_information.PVs.tmit.get()
+
+    def tmit_buffer(self, buffer: Buffer, **kwargs):
+        """Retrieve per-pulse TMIT data from timing buffer."""
+        return buffer.get(f"{self.controls_information.control_name}:TMIT", **kwargs)

--- a/slac_devices/toroid.py
+++ b/slac_devices/toroid.py
@@ -1,4 +1,6 @@
-from pydantic import SerializeAsAny
+from typing import Dict
+
+from pydantic import BaseModel, SerializeAsAny, field_validator
 
 from slac_devices.device import Device, PVSet, ControlInformation, Metadata
 from slac_timing import Buffer
@@ -39,3 +41,17 @@ class Toroid(Device):
     def tmit_buffer(self, buffer: Buffer, **kwargs):
         """Retrieve per-pulse TMIT data from timing buffer."""
         return buffer.get(f"{self.controls_information.control_name}:TMIT", **kwargs)
+
+
+class ToroidCollection(BaseModel):
+    toroids: Dict[str, SerializeAsAny[Toroid]]
+
+    @field_validator("toroids", mode="before")
+    def validate_toroids(cls, v) -> Dict[str, Toroid]:
+        for name, toroid in v.items():
+            if isinstance(toroid, Toroid):
+                continue
+            toroid = dict(toroid)
+            toroid.update({"name": name})
+            v.update({name: toroid})
+        return v

--- a/slac_devices/wire.py
+++ b/slac_devices/wire.py
@@ -107,6 +107,7 @@ class WireMetadata(Metadata):
     default_detector: str
     tmitloss: Optional[TMITLossBPMs] = None
     jitter_bpms: Optional[List[str]] = None
+    charge_toroids: Optional[List[str]] = None
     type: str
     wire_type: str
 


### PR DESCRIPTION
This pull request adds support for Toroid devices to the codebase, enabling their creation, management, and integration with existing device handling infrastructure. The main changes include the implementation of the `Toroid` class and its supporting classes, updates to the device reader logic, and minor enhancements to related metadata structures.

**Toroid device support:**

* Added a new `Toroid` class in `slac_devices/toroid.py`, along with supporting classes `ToroidPVSet`, `ToroidControlInformation`, and `ToroidMetadata`. These handle Toroid-specific process variables, control information, and metadata, and provide methods for accessing current and buffered TMIT values.
* Updated `slac_devices/reader.py` to import the new `Toroid` class and include "toroids" in the list of recognized device types and the device constructor map. 

**Device creation enhancements:**

* Added a new `create_toroid` function to `slac_devices/reader.py` for instantiating Toroid devices by area and name, with error handling for invalid or missing data.

**Metadata improvements:**

* Extended the `WireMetadata` class in `slac_devices/wire.py` to include an optional `charge_toroids` field, allowing wire devices to reference associated Toroids.